### PR TITLE
Fix Geode 5.5.0 regression

### DIFF
--- a/mod.json
+++ b/mod.json
@@ -23,7 +23,8 @@
       "name": "Enter Search",
       "description": "Search when you press enter in the level search page",
       "default": "Enter",
-      "category": "universal"
+      "category": "universal",
+      "allow-in-text-inputs": true
     }
   },
   "dependencies": {


### PR DESCRIPTION
Geode 5.5.0 introduces a minor behavior change where keyboard settings are not listened to inside text inputs by default and a config key was added for mods that use this functionality. This PR adds said key to the setting, so it can continue to work.